### PR TITLE
fix reading project path in hiper

### DIFF
--- a/tools/user/hiper/source/ui.d
+++ b/tools/user/hiper/source/ui.d
@@ -83,6 +83,7 @@ private void defaultShowErrorMessage(string title, string message)
 private string defaultShowSaveFileDialog(string initialName, string[] filters)
 {
     import std.stdio;
+    import std.string : chomp;
     writeln("Write a folder name to save HipProject: ", initialName);
-    return readln();
+    return readln().chomp();
 }


### PR DESCRIPTION
`readln` keeps the terminator by default, so unless you `chomp` you end up writing to a folder name containing a line ending.