### PR TITLE
fix projectgen postGenerateCommands for macos

### DIFF
--- a/tools/user/hiper/source/projectgen.d
+++ b/tools/user/hiper/source/projectgen.d
@@ -131,7 +131,7 @@ string generateDubProject(DubProjectInfo info, string projectPath)
 				"/WX"
 			],
 			"postGenerateCommands-windows": ["cd /d %s && dub -c script -- %s"],
-			"postGenerateCommands-linux": ["cd %s && dub -c script -- %s"]
+			"postGenerateCommands-posix": ["cd %s && dub -c script -- %s"]
 		}
 	],
 	"versions" : [


### PR DESCRIPTION
I don't see a reason why it should be different here between macos and linux.